### PR TITLE
Update create post

### DIFF
--- a/Controllers/PostControllers/createPost.js
+++ b/Controllers/PostControllers/createPost.js
@@ -11,8 +11,8 @@ exports.createPost = function createPost (req, res) {
     
     const {username} = req.user;
     const {datePosted, text, photos} = req.body;
-
-    db.Posts.insertOne({username: username, datePosted: datePosted, content: {text: text, photos: photos}})
+    
+    db.Posts.insertOne({username: username, datePosted: datePosted, content: {text: text, photos: photos}, likes: [], comments: []})
     .then(result => {
         return res.status(201).json(result);
     })

--- a/Tests/Controllers/PostControllers/createPost.test.js
+++ b/Tests/Controllers/PostControllers/createPost.test.js
@@ -13,7 +13,7 @@ describe('Check success when user submits a new create post form', () => {
     });
 
 
-    it('POST to /posts/create should return 400 if content is fully omitted. Text or photos is required.', async () => {
+    it('POST to /posts/create should return 400 if content (text/photos object) is fully omitted. Text or photos is required.', async () => {
 
         const res = await request(server).post('/posts/create').send({username: 'testuser15', datePosted: '2023-04-13 15:03'});
         expect(res.status).toBe(400);


### PR DESCRIPTION
- Added "likes" and "comments" as empty arrays to posts documents. So that we can correctly use PATH/updateOne instead of POST/insertOne when new likes and comments are added.
- Clarified the test description a little bit, to 'createUsers return 400 test'