### PR TITLE
Comment posts

### DIFF
--- a/Controllers/PostControllers/commentPost.js
+++ b/Controllers/PostControllers/commentPost.js
@@ -1,0 +1,22 @@
+const { ObjectId } = require("mongodb");
+const { db } = require("../../Database/Database");
+const { commentPostValidation } = require("../../Validations/commentValidation");
+
+
+exports.commentPost = async function commentPost (req, res) {
+
+    const validation = commentPostValidation(req.body);
+
+    if (validation.error) return res.status(400).send(validation.error.details[0].message);
+    
+    const {username} = req.user;
+    const {id, comment} = req.body;
+
+    db.Posts.updateOne({_id: new ObjectId(id)}, {$push: {comments: {username: username, comment: comment}}})
+    .then(result => {
+        return res.status(200).json(result);
+    })
+    .catch(err => {
+        return res.status(500).send(err);
+    })
+}

--- a/Routes/PostRoutes.js
+++ b/Routes/PostRoutes.js
@@ -3,9 +3,12 @@ const PostRoutes = express.Router();
 const { authenticateUser } = require('../middleware/checkAuthentication');
 const { createPost } = require('../Controllers/PostControllers/CreatePost');
 const { toggleLikePost } = require('../Controllers/PostControllers/likePost');
+const { commentPost } = require('../Controllers/PostControllers/commentPost');
 
 PostRoutes.post('/create', authenticateUser, createPost);
+
 PostRoutes.patch('/like/:id', authenticateUser, toggleLikePost); // "id" = only the 24 characters within the objectid(). Ex. 64394ad1f2c2cc88bb2ce77e
+PostRoutes.post('/comment', authenticateUser, commentPost); //should be patch for updates BUT we can't send long comments with whitespaces etc. in params/queries
 
 
 module.exports.PostRoutes = PostRoutes;

--- a/Validations/commentValidation.js
+++ b/Validations/commentValidation.js
@@ -1,0 +1,10 @@
+const joi = require("joi")
+
+const schema = joi.object({
+    id: joi.string().min(24).max(24).required(),
+    comment: joi.string().min(1).required()
+});
+
+exports.commentPostValidation = (body) => {
+    return schema.validate(body);
+}


### PR DESCRIPTION
- Created joi schema to validate post id and comments' body
- Created controller to send comments on posts. "Comments" field exists in all posts even when comments are empty, hence why it's updateOne and not insertOne.
- Added posts/comment route.
NOTE: Wanted to make it a patch route since it's an update and not an insert, but we can't send whitespaces and other characters that might be in a comment through params, therefore made it POST to get the comment through body. Please enlighten me if there is a better way.
NOTE2: Need to include the target post id from frontend in the body instead of params (unlike the "likes" endpoint)