### PR TITLE
switched the order of id and comment/like in url

### DIFF
--- a/Routes/PostRoutes.js
+++ b/Routes/PostRoutes.js
@@ -7,8 +7,8 @@ const { commentPost } = require('../Controllers/PostControllers/commentPost');
 
 PostRoutes.post('/create', authenticateUser, createPost);
 
-PostRoutes.patch('/like/:id', authenticateUser, toggleLikePost); // "id" = only the 24 characters within the objectid(). Ex. 64394ad1f2c2cc88bb2ce77e
-PostRoutes.patch('/comment/:id', authenticateUser, commentPost); //should be patch for updates BUT we can't send long comments with whitespaces etc. in params/queries
+PostRoutes.patch('/:id/like', authenticateUser, toggleLikePost); // "id" = only the 24 characters within the objectid(). Ex. 64394ad1f2c2cc88bb2ce77e
+PostRoutes.patch('/:id/comment', authenticateUser, commentPost); //should be patch for updates BUT we can't send long comments with whitespaces etc. in params/queries
 
 
 module.exports.PostRoutes = PostRoutes;


### PR DESCRIPTION
Switched the order in the url to comment and like posts. Makes a lot more sense to target the post and then its belonging comments and likes, than the other way around. Will correct in frontend as well.